### PR TITLE
Extract .default property from Example.js namespace object

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -5,7 +5,9 @@ import fakeDelay from './fakeDelay';
 import path from 'path';
 
 let LoadableExample = Loadable(
-  () => fakeDelay(400).then(() => import('./Example')),
+  () => fakeDelay(400).then(
+    () => import('./Example')
+  ).then(ex => ex.default),
   Loading,
   null,
   path.resolve(__dirname, './Example')


### PR DESCRIPTION
Excited by your article yesterday, I spent some time this morning finding out if `react-loadable` would work in [Meteor 1.5](https://github.com/meteor/meteor/pull/8327).

I'm happy to say that it [worked](https://github.com/meteor/meteor/pull/8327#issuecomment-286220281), and my [changes](https://github.com/meteor/react-loadable-example/commits/use-meteor) were mostly predictable: Meteor app layout, automatic Babel compilation, not needing Webpack, etc.

I should also stress that making `react-loadable` work in Meteor is entirely Meteor's responsibility, and not something I would've complained about if it hadn't worked. This pull request is inspired by one minor snag that I hit which seemed like it might be worth your attention.

If I'm reading the draft dynamic `import(...)` [spec](https://tc39.github.io/proposal-dynamic-import/#sec-finishdynamicimport) correctly, the `Promise` returned by `import(...)` is supposed to resolve to the "namespace" object of the imported module, which is (roughly speaking) an object containing all exported names, including a `default` property, if the module had a default export.

Although you've made this [work](https://github.com/thejameskyle/react-loadable/blob/5c8c9fd547bfef7a734a95ea2ca14f5dc13f044e/src/index.js#L38) via the `babelInterop` function, Babel seems to be [moving away](https://github.com/babel/babel/pull/5422) from the `__esModule` flag. I agree that calling `babelInterop` is perfectly reasonable for `react-loadable` today, but relying on that workaround won't work forever. In fact, it won't work today if the developer passes the [`noInterop`](https://www.npmjs.com/package/babel-plugin-transform-es2015-modules-commonjs#nointerop) option to the CommonJS modules transform.

In short, this change protects the example app from the inevitable future when `__esModule` stops being a thing.