### PR TITLE
Fix git clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Introductory blog post: https://medium.com/@thejameskyle/react-loadable-2674c59d
 
 **Running locally**
 
-```js
-git clone git@github.com:thejameskyle/react-loadable-example.git
+```
+git clone https://github.com/jamiebuilds/react-loadable-example
 cd react-loadable-example
 yarn install
 yarn start


### PR DESCRIPTION
The old URL was causing a "permission denied" error while cloning.

```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```